### PR TITLE
Style: remove space below footer

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -4,4 +4,5 @@
 
 .content-wrap {
   padding-bottom: 90px;
+  min-height: calc(100vh - 40px);
 }


### PR DESCRIPTION
Added minimum height for the content wrapper so the footer is stuck to the bottom across all screen size.